### PR TITLE
Improve dropdown

### DIFF
--- a/semantic-reflex-example/src/Example/Common.hs
+++ b/semantic-reflex-example/src/Example/Common.hs
@@ -60,6 +60,18 @@ instance DynShow t (Checkbox t) where
       , pure "\n  }"
       ]
 
+instance Show a => DynShow t (Dropdown t a) where
+  dynShow Dropdown {..} = do
+    change <- countWithLast _dropdown_change
+    pure $ mconcat
+      [ pure "Dropdown"
+      , (("\n  { _dropdown_value = " <>) . show) <$> _dropdown_value
+      , (("\n  , _dropdown_search = " <>) . T.unpack) <$> _dropdown_search
+      , (("\n  , _dropdown_change = " <>) . show) <$> change
+      , (("\n  , _dropdown_open = " <>) . show) <$> _dropdown_open
+      , pure "\n  }"
+      ]
+
 instance DynShow t (Progress t m) where
   dynShow Progress {..} = do
     pure $ mconcat

--- a/semantic-reflex-example/src/Example/Section/Dropdown.hs
+++ b/semantic-reflex-example/src/Example/Section/Dropdown.hs
@@ -31,8 +31,99 @@ dropdowns :: MonadWidget t m => Section t m
 dropdowns = Section "Dropdown" (simpleLink "https://semantic-ui.com/modules/dropdown.html") $ do
 
   hscode $(printDefinition id stripParens ''DropdownConfig)
+  hscode $(printDefinition id stripParens ''SearchDropdownConfig)
+  hscode $(printDefinition id stripParens ''Dropdown)
 
   pageHeader H3 def $ text "Dropdown"
+
+  mkExample "Dropdown" (def
+    & dynamic ?~ dynShowCode
+    & subtitle ?~ text "A standard dropdown")
+    [resetExample|
+  \resetEvent -> do
+    let conf = def { _dropdownConfig_placeholder = "State" }
+    dropdown conf Nothing (Nothing <$ resetEvent) $ TaggedStatic $ M.fromList $
+      ffor [minBound .. maxBound] $ \x -> (x, text (stateText x))
+  |]
+
+  mkExample "Unselectable Dropdown" (def
+    & dynamic ?~ dynShowCode
+    & subtitle ?~ text "An unselectable dropdown allows a user to reset the value by selecting it again")
+    [resetExample|
+  \resetEvent -> do
+    let conf = def
+          { _dropdownConfig_placeholder = "State"
+          , _dropdownConfig_unselectable = True
+          }
+    dropdown conf Nothing (Nothing <$ resetEvent) $ TaggedStatic $ M.fromList $
+      ffor [minBound .. maxBound] $ \x -> (x, text (stateText x))
+  |]
+
+  mkExample "Search Dropdown" (def
+    & dynamic ?~ dynShowCode
+    & subtitle ?~ text "A dropdown can be searchable")
+    [resetExample|
+  \resetEvent -> do
+    let conf = def
+          { _dropdownConfig_search = Just $ searchByToText countryText
+          , _dropdownConfig_placeholder = "Country"
+          }
+    dropdown conf Nothing (Nothing <$ resetEvent) $ TaggedStatic $ M.fromList $
+      ffor [minBound .. maxBound] $
+        \x -> (x, flag (pure $ T.toLower $ tshow x) def >> text (countryText x))
+  |]
+
+  mkExample "Custom Dropdown" (def
+    & dynamic ?~ dynShowCode
+    & subtitle ?~ text "A dropdown can use a different wrapper")
+    [resetExample|
+  \resetEvent -> do
+    let conf = def
+          { _dropdownConfig_search = Just $ searchByToText countryText
+          , _dropdownConfig_placeholder = "Country"
+          , _dropdownConfig_selection = pure False
+          }
+    dropdownWithWrapper (\f -> label' (f def)) conf Nothing (Nothing <$ resetEvent) $
+      TaggedStatic $ M.fromList $ ffor [minBound .. maxBound] $
+        \x -> (x, flag (pure $ T.toLower $ tshow x) def >> text (countryText x))
+  |]
+
+  mkExample "Search Dropdown (allow additions)" (def
+    & dynamic ?~ dynCode
+    & subtitle ?~ text "A searchable dropdown can allow the user to enter a new value")
+    [resetExample|
+  \resetEvent -> do
+    let conf = def
+          { _dropdownConfig_search = Just $ (searchByToText countryText)
+            { _searchDropdownConfig_allowAdditions = True }
+          , _dropdownConfig_placeholder = "Country"
+          }
+    d <- dropdown conf Nothing (Nothing <$ resetEvent) $ TaggedStatic $ M.fromList $
+      ffor [minBound .. maxBound] $
+        \x -> (x, flag (pure $ T.toLower $ tshow x) def >> text (countryText x))
+    pure $ ffor (allowAdditionsValue d) $ \x -> case x of
+      Left t -> "Some other place, " <> t
+      Right (Just a) -> "A known place, " <> countryText a
+      Right Nothing -> "Choose a place!"
+  |]
+
+  mkExample "Identity Dropdown" (def
+    & dynamic ?~ dynShowCode
+    & subtitle ?~ text "A dropdown can always have a value")
+    [resetExample|
+  \resetEvent -> do
+    let conf = def { _dropdownConfig_placeholder = "State" }
+    dropdown conf (Identity NY) (Identity NY <$ resetEvent) $ TaggedStatic $ M.fromList $
+      ffor [minBound .. maxBound] $ \x -> (x, text (stateText x))
+  |]
+
+  mkExample "Text Dropdown" (def
+    & dynamic ?~ dynShowCode
+    & subtitle ?~ text "A text input that can provide suggestions in a dropdown")
+    [resetExample|
+  \resetEvent -> do
+    textDropdown def "" ("" <$ resetEvent) $ TaggedStatic ["one", "two", "three"]
+  |]
 
   mkExample "Static or Dynamic Dropdown" (def
     & dynamic ?~ dynCode
@@ -45,210 +136,10 @@ dropdowns = Section "Dropdown" (simpleLink "https://semantic-ui.com/modules/drop
         render = M.fromList [ (i, text $ tshow i) | i <- items ]
 
     e <- dyn $ ffor on $ \o -> case o of
-      True -> dropdown (def & dropdownConfig_placeholder |~ "Static") Nothing $
+      True -> dropdown (def & dropdownConfig_placeholder |~ "Static") Nothing never $
         TaggedStatic render
-      False -> dropdown (def & dropdownConfig_placeholder |~ "Dynamic") Nothing $
+      False -> dropdown (def & dropdownConfig_placeholder |~ "Dynamic") Nothing never $
         TaggedDynamic $ pure render
     join <$> holdDyn (pure Nothing) (value <$> e)
   |]
 
-  mkExample "Dropdown" (def
-    & dynamic ?~ dynCode
-    & subtitle ?~ text "A standard dropdown")
-    [resetExample|
-  \resetEvent -> do
-    d <- dropdown def (Just 1) $ TaggedStatic $ 1 =: (text "one") <> 2 =: (text "two")
-    return $ value d
-  |]
-
-  mkExample "Dropdown" (def
-    & dynamic ?~ dynCode
-    & subtitle ?~ text "A standard dropdown")
-    [resetExample|
-  \resetEvent -> do
-    d <- dropdown def (Identity 1) $ TaggedStatic $ 1 =: (text "one") <> 2 =: (text "two")
-    return $ value d
-  |]
-
-  mkExample "Dropdown" (def
-    & dynamic ?~ dynCode
-    & subtitle ?~ text "A standard dropdown")
-    [resetExample|
-  \resetEvent -> do
-    d <- dropdown def [2] $ TaggedStatic $ 1 =: (text "one") <> 2 =: (text "two")
-    return $ value d
-  |]
-
-{-
-  ui_ $ Example "Dropdown" (def & subtitle ?~ text "A simple dropdown" & dynamic ?~ dynCode)
-    [resetExample|
---    ui $ Header (def & icon ?~ Icon "tag" def) $ text "Filter by tag"
---    ui $ Divider def
---    ui $ MenuItem "important" def $ text "Important"
---    ui $ MenuItem "announcement" def $ text "Announcement"
---    ui_ $ MenuItem "discussion" def $ text "Discussion"
---    void $ dyn $ ffor togg $ \case
---      True -> ui $ MenuItem "A" def $ text "A"
---      False -> ui $ MenuItem "B" def $ text "B"
-  |]
--}
-
---  ui_ $ Divider def
---
---  ddval <- ui $ MenuDropdown (mkDropdownConfig Nothing & selection |~ True) $
---    for_ [1..100] $ \i -> ui $ MenuItem i def $ text $ TaggedStatic $ tshow i
---
---  ui_ $ Divider $ def & hidden |~ True
---
---  display ddval
---
---  ui_ $ Divider def
-
---  ddval <- ui $ SelectionDropdown (mkDropdownConfig Nothing & selection |~ True) (return ()) $
---    TaggedStatic $ for [1..100] $ \i -> simpleItem i
-
-  return ()
-{-
-  divClass "ui two column stackable grid" $ do
-    divClass "row" $ do
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Single value" "" [mkExample|
-        \resetEvent -> do
-          clearEvent <- ui $ Button "Clear Value" $ def
-            & attached |?~ Horizontally LeftAttached
-          let mkItem card = DropdownItem card (showCard card) $ def
-                & icon ?~ Icon (pure . T.toLower $ tshow card) def
-              cards = map mkItem [minBound..maxBound]
-          ui $ Dropdown cards
-            $ def & placeholder .~ "Card Type"
-                  & setValue .~ leftmost [Just Visa <$ resetEvent, Nothing <$ clearEvent]
-                  & initialValue ?~ Visa
-                  & selection .~ True
-        |]
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Single value, search" "" [mkExample|
-        \resetEvent -> do
-          let mkItem contact = DropdownItem contact (showContact contact) $ def
-                & image ?~ Image (src contact) (def & size |?~ Mini & avatar |~ True)
-              src contact = pure $ "http://semantic-ui.com/images/avatar/small/"
-                          <> T.toLower (tshow contact) <> ".jpg"
-              contacts = map mkItem [minBound..maxBound]
-          ui $ Dropdown contacts
-            $ def & placeholder .~ "Saved Contacts"
-                  & setValue .~ (Nothing <$ resetEvent)
-                  & selection .~ True
-                  & search .~ True
-                  & textOnly .~ True
-        |]
-
-  el "p" $ text "Dropdown values can be definite: that is, they are guaranteed to have a value and cannot be deselected by the user."
-
-  divClass "ui warning message" $ do
-    ui $ Icon "warning sign" def
-    text "If you fire a setValue event with a non-existant value, the event will be ignored."
-
-  divClass "ui two column stackable grid" $ do
-    divClass "row" $ do
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Single value inline menu" "A dropdown can be formatted to appear inline in other content" [mkExample|
-        \resetEvent -> el "span" $ do
-          let mkItem contact = DropdownItem contact (showContact contact) $ def
-                & image ?~ Image (src contact) (def & avatar |~ True)
-              src contact = pure $ "https://semantic-ui.com/images/avatar/small/"
-                          <> T.toLower (tshow contact) <> ".jpg"
-              contacts = map mkItem [minBound..maxBound]
-          text $ "Show me posts by "
-          ui $ Dropdown contacts
-            $ pure (Identity Jenny)
-                & inline .~ True
-                & setValue .~ (Identity Jenny <$ resetEvent)
-        |]
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Single value inline menu" "A dropdown can be formatted to appear inline in other content" [mkExample|
-        \resetEvent -> do
-          setEvent <- ui $ Button "Set Value Incorrectly" def
-          ui $ Header H4 ( do
-            text "Trending repos "
-            ui $ Dropdown
-              [ Content $ Header H1 (text "Adjust time span") def
-              , Content Divider
-              , DropdownItem "daily" "Today" $ def & dataText ?~ "today"
-              , DropdownItem "weekly" "This Week" $ def & dataText ?~ "this week"
-              , DropdownItem "monthly" "This Month" $ def & dataText ?~ "this month"
-              ]
-              $ pure (Identity ("daily" :: Text))
-                  & inline .~ True
-                  & setValue .~ leftmost
-                    [ Identity "daily" <$ resetEvent
-                    , Identity "error" <$ setEvent ]
-            ) $ def & icon .~ AlwaysRender (Icon "trophy" def)
-        |]
-
-    divClass "row" $ do
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Multi value" "" [mkExample|
-        \resetEvent -> do
-          let mkItem card = DropdownItem card (showCard card) $ def
-                & icon ?~ Icon (pure . T.toLower $ tshow card) def
-              cards = map mkItem [minBound..maxBound]
-          ui $ Dropdown cards
-            $ def & placeholder .~ "Card Type"
-                  & setValue .~ ([] <$ resetEvent)
-                  & selection .~ True
-                  & textOnly .~ True
-        |]
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Multi value, full-text search" "" [mkExample|
-        \resetEvent -> do
-          let mkItem contact = DropdownItem contact (showContact contact) $ def
-                & image ?~ Image (src contact) (def & size |?~ Mini & avatar |~ True)
-                & dataText ?~ (T.unwords $ take 1 $ T.words $ showContact contact)
-              src contact = pure $ "http://semantic-ui.com/images/avatar/small/"
-                          <> T.toLower (tshow contact) <> ".jpg"
-              contacts = map mkItem [minBound..maxBound]
-          ui $ Dropdown contacts
-            $ def & placeholder .~ "Saved Contacts"
-                  & setValue .~ ([Matt, Elliot] <$ resetEvent)
-                  & initialValue .~ [Matt, Elliot]
-                  & fullTextSearch .~ True
-                  & selection .~ True
-                  & search .~ True
-        |]
-
-    divClass "row" $ do
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Multi value, limited " "" [mkExample|
-        \resetEvent -> do
-          let mkItem state = DropdownItem state (stateText state) $ def
-              states = map mkItem [minBound..maxBound]
-          ui $ Dropdown states
-            $ def & placeholder .~ "States"
-                  & setValue .~ ([] <$ resetEvent)
-                  & maxSelections ?~ 3
-                  & selection .~ True
-        |]
-
-      divClass "column" $ do
-        exampleCardDyn dynCode "Multi value, search, hidden labels " "" [mkExample|
-        \resetEvent -> do
-          let mkItem country = DropdownItem country (countryText country) $ def
-                & flag ?~ Flag (pure $ T.toLower $ T.pack $ show country)
-              countries = map mkItem [minBound..maxBound]
-          ui $ Dropdown countries
-            $ def & placeholder .~ "Country"
-                  & setValue .~ ([] <$ resetEvent)
-                  & useLabels .~ False
-                  & selection .~ True
-                  & search .~ True
-        |]
-
-  return ()
-
--}

--- a/semantic-reflex/src/Reflex/Dom/SemanticUI/Dropdown.hs
+++ b/semantic-reflex/src/Reflex/Dom/SemanticUI/Dropdown.hs
@@ -2,115 +2,151 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Reflex.Dom.SemanticUI.Dropdown where
+-- | Semantic-UI Dropdown widgets
+--
+-- <https://semantic-ui.com/modules/dropdown.html>
+module Reflex.Dom.SemanticUI.Dropdown
+  (
 
+  -- * Single select dropdowns
+    dropdown
+  , dropdownWithWrapper
+  , textDropdown
+  , Dropdown(..)
+  , DropdownConfig(..)
+
+  -- * Searchable dropdown configuration
+  , SearchDropdownConfig(..)
+  , searchByToText
+  , searchByShow
+  , allowAdditionsValue
+
+  -- * Lenses
+  , dropdown_value
+  , dropdown_search
+  , dropdown_change
+  , dropdown_open
+  , dropdown_element
+
+  , dropdownConfig_placeholder
+  , dropdownConfig_selection
+  , dropdownConfig_compact
+  , dropdownConfig_fluid
+  , dropdownConfig_inline
+  , dropdownConfig_unselectable
+  , dropdownConfig_pointing
+  , dropdownConfig_upward
+  , dropdownConfig_search
+
+  , searchDropdownConfig_function
+  , searchDropdownConfig_allowAdditions
+
+  ) where
+
+import Control.Lens
 import Control.Lens.TH (makeLensesWith, lensRules, simpleLenses)
-
-import Control.Lens ((<&>), (?~))
 import Control.Monad.Reader
 import Data.Bool (bool)
-import Data.Foldable (for_, traverse_)
-import Data.Maybe (fromMaybe)
 import Data.Default
+import Data.Foldable (for_, traverse_)
+import Data.Map.Lazy (Map)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Traversable (for)
 import Language.Javascript.JSaddle (liftJSM)
 import Reflex hiding (list)
-import Data.Map.Lazy (Map)
+import Reflex.Dom.Builder.Class
+import Reflex.Dom.Class
+import Reflex.Dom.Core (El, GhcjsDomSpace, HasValue(..), keydown)
+import Reflex.Dom.Widget.Basic
+
+import qualified Data.Map.Lazy as M
+import qualified Data.Text as T
+import qualified GHCJS.DOM.Element as Element
+import qualified GHCJS.DOM.EventM as EventM
+import qualified GHCJS.DOM.GlobalEventHandlers as GlobalEventHandlers
+import qualified GHCJS.DOM.HTMLElement as HTMLElement
+import qualified GHCJS.DOM.Types as Types
 
 import Reflex.Active
 import Reflex.Dom.SemanticUI.Common
 import Reflex.Dom.SemanticUI.Transition
 import Reflex.Dom.SemanticUI.Icon
-import Reflex.Dom.SemanticUI.Input
 
-import Reflex.Dom.Core hiding (SetValue, Dropdown(..), DropdownConfig, list, textInput)
+-- | Configuration for searchable dropdowns. You can use 'searchByToText' or
+-- 'searchByShow' to construct this easily.
+data SearchDropdownConfig a = SearchDropdownConfig
+  { _searchDropdownConfig_function :: Text -> a -> Bool
+  -- ^ The function used for searching items. First argument is the text in the
+  -- search box, second value is some item from the list.
+  , _searchDropdownConfig_allowAdditions :: Bool
+  -- ^ By default, when a user exits a searchable dropdown without choosing an
+  -- item, the search text is cleared. When allowAdditions is set, the text is
+  -- not cleared. You should use 'allowAdditionsValue' to get the current value.
+  }
+makeLensesWith (lensRules & simpleLenses .~ True) ''SearchDropdownConfig
 
-import qualified GHCJS.DOM.EventM as EventM
-import qualified GHCJS.DOM.GlobalEventHandlers as GlobalEventHandlers
-import qualified GHCJS.DOM.HTMLElement as HTMLElement
-import qualified GHCJS.DOM.Element as Element
-import qualified GHCJS.DOM.Types as Types
+-- | Case insensitive search through the text given by a function
+searchByToText :: (a -> Text) -> SearchDropdownConfig a
+searchByToText toText = SearchDropdownConfig
+  { _searchDropdownConfig_function = \s a ->
+    T.toCaseFold s `T.isInfixOf` T.toCaseFold (toText a)
+  , _searchDropdownConfig_allowAdditions = False
+  }
 
-import qualified Data.Map.Lazy as M
-
-{-
-data DropdownAction
-  = Activate
-  | Combo
-  | Select
-  | Hide
-  deriving (Eq, Show)
-
-instance ToJSVal DropdownAction where
-  toJSVal action = valMakeString $ case action of
-    Activate -> "activate"
-    Combo -> "combo"
-    -- Select doesn't seem to work, so we use activate and prevent the text from
-    -- being set in the dropdown element by removing the wrapping "default text"
-    -- div around the placeholder.
-    Select -> "activate"
-    Hide -> "hide"
--}
-
-data DropdownStyle = DropdownButton | DropdownLabel
-  deriving (Eq, Ord, Read, Show, Enum, Bounded)
-
-instance ToClassText DropdownStyle where
-  toClassText DropdownButton = "button"
-  toClassText DropdownLabel = "label"
+-- | Case insensitive search through the text given by the 'Show' instance
+searchByShow :: Show a => SearchDropdownConfig a
+searchByShow = searchByToText $ T.pack . show
 
 -- | Config for new semantic dropdowns
-data DropdownConfig t = DropdownConfig
---  { _dropdownConfig_Value :: SetValue t a
+data DropdownConfig t a = DropdownConfig
   { _dropdownConfig_placeholder :: Dynamic t Text
+  -- ^ Placeholder text
   , _dropdownConfig_selection :: Dynamic t Bool
+  -- ^ Selection dropdowns appear like form inputs
   , _dropdownConfig_compact :: Dynamic t Bool
+  -- ^ A compact dropdown has no minimum width
   , _dropdownConfig_fluid :: Dynamic t Bool
-  , _dropdownConfig_item :: Dynamic t Bool
+  -- ^ Fluid dropdowns flow to fill their container
   , _dropdownConfig_inline :: Dynamic t Bool
-  , _dropdownConfig_as :: Dynamic t (Maybe DropdownStyle)
+  -- ^ A dropdown can be formatted to appear inline in other content
   , _dropdownConfig_unselectable :: Bool
-  , _dropdownConfig_closeOnClickSelection :: Bool
-  , _dropdownConfig_searchValue :: Event t Text
-  , _dropdownConfig_searchFunction :: Text -> Text -> Bool
-  -- ^ The function used for searching items. Should return 'True' when the
-  -- first argument is in the second argument. Default implementation is case
-  -- insensitive 'T.isInfixOf'.
-  , _dropdownConfig_elConfig :: ActiveElConfig t
+  -- ^ If this is true and an item is clicked when it is already the current
+  -- value, the value will be reset to the initial value
+  , _dropdownConfig_pointing :: Dynamic t Bool
+  -- ^ A dropdown menu can be pointing
+  , _dropdownConfig_upward :: Dynamic t Bool
+  -- ^ The menu can open upwards instead of downwards
+  , _dropdownConfig_search :: Maybe (SearchDropdownConfig a)
+  -- ^ A dropdown can have a search input for narrowing a list of results
   }
 makeLensesWith (lensRules & simpleLenses .~ True) ''DropdownConfig
 
-instance HasElConfig t (DropdownConfig t) where
-  elConfig = dropdownConfig_elConfig
-
-instance Reflex t => Default (DropdownConfig t) where
+instance Reflex t => Default (DropdownConfig t a) where
   def = DropdownConfig
     { _dropdownConfig_placeholder = pure mempty
-    , _dropdownConfig_selection = pure False
+    , _dropdownConfig_selection = pure True
     , _dropdownConfig_compact = pure False
     , _dropdownConfig_fluid = pure False
-    , _dropdownConfig_item = pure False
     , _dropdownConfig_inline = pure False
-    , _dropdownConfig_as = pure Nothing
+    , _dropdownConfig_pointing = pure False
+    , _dropdownConfig_upward = pure False
     , _dropdownConfig_unselectable = False
-    , _dropdownConfig_closeOnClickSelection = True
-    , _dropdownConfig_searchValue = never
-    , _dropdownConfig_searchFunction = \s t -> T.toCaseFold s `T.isInfixOf` T.toCaseFold t
-    , _dropdownConfig_elConfig = def
+    , _dropdownConfig_search = Nothing
     }
 
 dropdownConfigClasses
-  :: Reflex t => DropdownConfig t -> Dynamic t Bool -> Dynamic t Classes
+  :: Reflex t => DropdownConfig t a -> Dynamic t Bool -> Dynamic t Classes
 dropdownConfigClasses DropdownConfig {..} isOpen = dynClasses'
-  [ pure $ Just "ui selection dropdown"
+  [ pure $ Just "ui dropdown"
   , boolClass "compact" _dropdownConfig_compact
   , boolClass "fluid" _dropdownConfig_fluid
   , boolClass "selection" _dropdownConfig_selection
-  , boolClass "item" _dropdownConfig_item
   , boolClass "inline" _dropdownConfig_inline
+  , boolClass "pointing" _dropdownConfig_pointing
+  , boolClass "upward" _dropdownConfig_upward
   , boolClass "active" isOpen
-  , fmap toClassText <$> _dropdownConfig_as
+  , pure $ "search" <$ _dropdownConfig_search
   ]
 
 lookupNextKey :: (Foldable f, Monad f, Ord k) => f k -> f k -> Map k a -> f k
@@ -131,10 +167,18 @@ lookupPrevKey ini mCurrent m
     Just i -> pure $ fst $ M.elemAt (max 0 $ pred i) m
     Nothing -> ini
 
+-- | Result of running a 'dropdown'
 data Dropdown t a = Dropdown
   { _dropdown_value :: Dynamic t a
-  , _dropdown_blur :: Event t ()
+  -- ^ Currently selected value
+  , _dropdown_search :: Dynamic t Text
+  -- ^ Current entry in the search box, if present
+  , _dropdown_change :: Event t a
+  -- ^ User driven change events
+  , _dropdown_open :: Dynamic t Bool
+  -- ^ Is the menu open?
   , _dropdown_element :: El t
+  -- ^ Wrapper element
   }
 makeLensesWith (lensRules & simpleLenses .~ True) ''Dropdown
 
@@ -142,36 +186,102 @@ instance HasValue (Dropdown t a) where
   type Value (Dropdown t a) = Dynamic t a
   value = _dropdown_value
 
+-- | Get a 'Dynamic' of 'Either' some user added 'Text' value or a real selection.
+-- Useful in conjunction with '_searchDropdownConfig_allowAdditions' = 'True'.
+allowAdditionsValue :: Reflex t => Dropdown t a -> Dynamic t (Either Text a)
+allowAdditionsValue d = f <$> _dropdown_search d <*> value d <*> _dropdown_open d
+  where f search a open
+          | open || T.null search = Right a
+          | otherwise = Left search
+
+-- | Single selection dropdown widget
 dropdown
   :: forall active t m k f.
     ( SingActive active, Monad f, Ord k, UI t m, Ord (f k), Foldable f
     , Types.MonadJSM (Performable m), Types.MonadJSM m, DomBuilderSpace m ~ GhcjsDomSpace )
-  => DropdownConfig t -> f k -> TaggedActive active t (Map k (m ()))
+  => DropdownConfig t k
+  -> f k
+  -> Event t (f k)
+  -> TaggedActive active t (Map k (m ()))
   -> m (Dropdown t (f k))
-dropdown config@DropdownConfig {..} ini items = mdo
+dropdown = dropdownWithWrapper $ \f -> ui' "div" (f def)
 
-  let elConf = _dropdownConfig_elConfig <> def
-        { _classes = Dyn $ dropdownConfigClasses config isOpen
-        , _attrs = pure ("tabindex" =: "0")
-        }
+-- | Single selection dropdown widget, with custom wrapper. This can, for
+-- example, be used to turn labels into dropdowns:
+--
+-- > dropdownWithWrapper (\f -> label' (f def)) def Nothing never items
+--
+-- You'll probably want to set _dropdownConfig_selection to 'False' when using
+-- this.
+--
+dropdownWithWrapper
+  :: forall active t m k f.
+    ( SingActive active, Monad f, Ord k, UI t m, Ord (f k), Foldable f
+    , Types.MonadJSM (Performable m), Types.MonadJSM m, DomBuilderSpace m ~ GhcjsDomSpace )
+  => (forall x. (forall cfg. HasElConfig t cfg => cfg -> cfg) -> m x -> m (El t, x))
+  -> DropdownConfig t k
+  -> f k
+  -> Event t (f k)
+  -> TaggedActive active t (Map k (m ()))
+  -> m (Dropdown t (f k))
+dropdownWithWrapper wrapper config@DropdownConfig {..} ini setVal items = mdo
 
-  (e, (selection, clickItem)) <- ui' "div" elConf $ mdo
-    icon "dropdown" def
+  let alterConfig :: forall cfg. HasElConfig t cfg => cfg -> cfg
+      alterConfig cfg = cfg
+        & classes <>~ Dyn (dropdownConfigClasses config isOpen)
+        & attrs <>~ pure (M.singleton "tabindex" "0")
+      search :: Maybe (Dynamic t Text)
+      search = value <$> searchInput
 
-    void $ dyn $ ffor dSelection $ \f ->
-      if null f
-      then divClass "default text" $ dynText _dropdownConfig_placeholder
-      else for_ f $ \k -> void $ divClass "text" $ taggedActive id (void . dyn)
-        $ fromMaybe blank . M.lookup k <$> items
+  -- Wrapper element
+  (dropdownElement, (searchInput, clickItem)) <- wrapper alterConfig $ mdo
 
-    (menuEl, (clickItem, dSelection)) <- ui' "div" (dropdownMenuConfig $ updated isOpen) $ do
-      (elemMap, eMaybeK) <- taggedActiveSelectViewListWithKey dSelection
-        (M.mapKeysMonotonic pure <$> items) $ \_k v dSelected -> do
-          let itemConf = def & classes .~ Dyn dClasses
-              dClasses = dSelected <&> \case
-                True -> "item active selected"
-                False -> "item"
-          (itemEl, _) <- ui' "div" itemConf $ taggedActive id (void . dyn) v
+    -- Add the search text input element when required
+    searchInput <- for _dropdownConfig_search $ \_ -> do
+      i <- inputElement $ def
+        & initialAttributes .~ M.singleton "class" "search"
+        & inputElementConfig_setValue .~ leftmost
+          [ "" <$ anyChoice
+          , case _dropdownConfig_search of
+            Just SearchDropdownConfig {..} | _searchDropdownConfig_allowAdditions -> never
+            _ -> "" <$ ffilter not (updated isOpen)
+          ]
+      -- Prevent the click events from propagating to the wrapper element
+      let htmlEl = Types.uncheckedCastTo Types.HTMLElement $ _inputElement_raw i
+      void $ liftJSM $ EventM.on htmlEl GlobalEventHandlers.click $ EventM.stopPropagation
+      pure i
+
+    -- Selected element / default text
+    let mkTextClasses sel mtxt = T.unwords $ fmapMaybe id
+          [ Just "text"
+          , "default" <$ guard (null sel)
+          , case mtxt of
+            Just t | not (T.null t) -> Just "filtered"
+            _ -> Nothing
+          ]
+    elDynClass "div" (mkTextClasses <$> selection <*> sequence search) $
+      dyn_ $ ffor selection $ \sel ->
+        if null sel
+        then dynText _dropdownConfig_placeholder
+        else for_ sel $ \k -> taggedActive id (void . dyn) $ fromMaybe blank . M.lookup k <$> items
+
+    -- Togglable menu with list of items
+    (menuEl, clickItem) <- ui' "div" (mkMenuConfig _dropdownConfig_upward $ updated isOpen) $ do
+
+      -- List the items
+      (elemMap, userClickItem :: Event t k) <-
+        taggedActiveSelectViewListWithKey' selection items $ \k v isSelected -> do
+          let mkClasses selected visible = mconcat
+                [ "item"
+                , if selected then "selected" else ""
+                , if Just False == visible then "filtered" else ""
+                ]
+              cs = mkClasses <$> isSelected <*> sequence isVisible
+              isVisible = do
+                SearchDropdownConfig {..} <- _dropdownConfig_search
+                ds <- search
+                pure $ flip _searchDropdownConfig_function k <$> ds
+          (itemEl, _) <- ui' "div" (def & classes .~ Dyn cs) $ taggedActive id (void . dyn) v
 
           -- Prevent the click events from propagating to the wrapper element
           -- These click events are used to close the menu, and click events on
@@ -179,37 +289,70 @@ dropdown config@DropdownConfig {..} ini items = mdo
           let itemHTML = Types.uncheckedCastTo Types.HTMLElement $ _element_raw itemEl
           void $ liftJSM $ EventM.on itemHTML GlobalEventHandlers.click $ EventM.stopPropagation
 
-          pure (itemEl, domEvent Click itemEl)
+          pure ((isVisible, itemEl), domEvent Click itemEl)
 
-      alterScroll menuEl dSelection elemMap
+      -- Display a message if all items have been filtered out
+      for_ _dropdownConfig_search $ \_ -> do
+        let visible = do
+              m <- taggedActive pure id elemMap
+              or <$> sequence (M.mapMaybe fst m)
+        dyn_ $ ffor visible $ \v -> unless v $
+          divClass "message" $ text "No results found."
 
-      fmap ((,) (void eMaybeK)) $ holdDyn ini $ leftmost
-        [ flip tag (keydown ArrowDown e) $ lookupNextKey ini
-            <$> current dSelection <*> taggedActive pure current items
-        , flip tag (keydown ArrowUp e) $ lookupPrevKey ini
-            <$> current dSelection <*> taggedActive pure current items
+      -- Adjust scroll position if the selected element is out of view
+      alterScroll menuEl selection $ M.map snd . M.mapKeysMonotonic pure <$> elemMap
+
+      pure userClickItem
+
+    icon "dropdown" $ def & iconConfig_flipped .~ Dyn
+      (bool Nothing (Just VerticallyFlipped) <$> _dropdownConfig_upward)
+    pure (searchInput, clickItem)
+
+      -- Changes caused by user interactions
+  let userChoice :: Event t (f k) = leftmost
+        [ flip tag (keydown ArrowDown dropdownElement) $ lookupNextKey ini
+            <$> current selection <*> taggedActive pure current items
+        , flip tag (keydown ArrowUp dropdownElement) $ lookupPrevKey ini
+            <$> current selection <*> taggedActive pure current items
         , case _dropdownConfig_unselectable of
-          True -> attachWith (\old new -> if old == new then ini else new)
-            (current dSelection) eMaybeK
-          False -> eMaybeK
+          True -> attachWith (\old new -> if old == pure new then ini else pure new)
+            (current selection) clickItem
+          False -> pure <$> clickItem
         ]
+      -- Changes caused by user or setVal
+      anyChoice = leftmost [userChoice, setVal]
 
-    pure (dSelection, clickItem)
+  -- Currently selected value
+  selection :: Dynamic t (f k) <- holdDyn ini anyChoice
 
-  -- Add event listeners
-  let htmlElement = Types.uncheckedCastTo Types.HTMLElement $ _element_raw e
+  -- Stop keyboard events from escaping the dropdown context
+  let htmlElement = Types.uncheckedCastTo Types.HTMLElement $ _element_raw dropdownElement
   void $ liftJSM $ EventM.on htmlElement GlobalEventHandlers.keyDown $ do
     EventM.uiKeyCode >>= \k -> case keyCodeLookup (fromIntegral k) of
-      Space -> EventM.preventDefault
       ArrowDown -> EventM.preventDefault
       ArrowUp -> EventM.preventDefault
       Escape -> HTMLElement.blur htmlElement
       _ -> pure ()
 
-  let toggleEvents = domEvent Click e <> keydown Space e <> keydown Enter e
-      closeEvents = domEvent Blur e <> if _dropdownConfig_closeOnClickSelection then clickItem else never
-      openEvents = keydown ArrowDown e <> keydown ArrowUp e
-
+  -- Determine when to open / close the menu
+  let searchFocusChange = maybe never (updated . _inputElement_hasFocus) searchInput
+      (searchFocus, searchBlur) = fanEither $ ffor searchFocusChange $ \case
+        True -> Left ()
+        False -> Right ()
+      toggleEvents = leftmost
+        [ domEvent Click dropdownElement
+        , keydown Enter dropdownElement
+        ]
+      closeEvents = leftmost
+        [ domEvent Blur dropdownElement
+        , void clickItem
+        , searchBlur
+        ]
+      openEvents = leftmost
+        [ keydown ArrowDown dropdownElement
+        , keydown ArrowUp dropdownElement
+        , searchFocus
+        ]
   isOpen <- holdUniqDyn <=< holdDyn False $ leftmost
     [ False <$ closeEvents, True <$ openEvents
     , not <$> tag (current isOpen) toggleEvents
@@ -217,21 +360,23 @@ dropdown config@DropdownConfig {..} ini items = mdo
 
   pure $ Dropdown
     { _dropdown_value = selection
-    , _dropdown_blur = closeEvents
-    , _dropdown_element = e
+    , _dropdown_search = fromMaybe "" search
+    , _dropdown_change = userChoice
+    , _dropdown_open = isOpen
+    , _dropdown_element = dropdownElement
     }
 
 -- | Dropdown menu element config, this hides/shows the menu according to the
 -- input event
-dropdownMenuConfig :: Reflex t => Event t Bool -> ActiveElConfig t
-dropdownMenuConfig transition = def
+mkMenuConfig :: Reflex t => Dynamic t Bool -> Event t Bool -> ActiveElConfig t
+mkMenuConfig upward transition = def
   & classes |~ "menu"
   & action ?~ def
     { _action_initialDirection = Out
-    , _action_transition = mkTransition <$> transition
+    , _action_transition = attachWith mkTransition (current upward) transition
     , _action_transitionStateClasses = forceVisible
     }
-  where mkTransition open = Transition SlideDown (Just $ if open then In else Out) $ def
+  where mkTransition up open = Transition (if up then SlideUp else SlideDown) (Just $ if open then In else Out) $ def
           & transitionConfig_duration .~ 0.2
           & transitionConfig_cancelling .~ True
 
@@ -259,105 +404,28 @@ alterScroll menuEl' val elMap = do
 
 -- | Searchable text dropdown. Behaves mostly like a text input, but with values
 -- that can also be selected from a dropdown box.
-searchDropdown
-  :: forall active t m k.
-    ( SingActive active, UI t m, Types.MonadJSM (Performable m)
-    , Types.MonadJSM m, DomBuilderSpace m ~ GhcjsDomSpace )
-  => DropdownConfig t -> Text -> TaggedActive active t [(k, Text)]
-  -> m (Dropdown t (Text, Maybe (k, Text)))
-searchDropdown config@DropdownConfig {..} ini items = mdo
-
-  let elConf = _dropdownConfig_elConfig <> def
-        { _classes = Dyn $ ("search" <>) <$>  dropdownConfigClasses config isOpen }
-      itemMap = M.fromList . zipWith (\i t -> (Just i, t)) [0..] <$> items
-      search = _textInput_value searchInput
-
-  (dropdownElement, (clickIndex, searchInput, ic)) <- ui' "div" elConf $ mdo
-    ic <- icon' "dropdown" def
-
-    searchInput <- textInput $ def
-      & textInputConfig_attrs |~ "class" =: "search"
-      & textInputConfig_placeholder .~ _dropdownConfig_placeholder
-      & textInputConfig_value .~ SetValue ini (Just $ leftmost [_dropdownConfig_searchValue, snd <$> choose])
-
-    (menuEl, (elemMap, clickIndex)) <- ui' "div" (dropdownMenuConfig $ updated isOpen) $
-      taggedActiveSelectViewListWithKey hover itemMap $ \_ val selected -> do
-        let selectedClass = bool "" "active selected" <$> selected
-            filtered s (_ :: k, t) = if _dropdownConfig_searchFunction s t
-                           then "" else "filtered" :: Classes
-            c = zipDynWith (\s f -> mconcat ["item", s, f]) selectedClass $ case val of
-              TaggedStatic t -> ffor search $ \s -> filtered s t
-              TaggedDynamic dt -> zipDynWith filtered search dt
-        (itemEl, _) <- ui' "div" (def & classes .~ Dyn c) $ taggedActive text dynText $ fmap snd val
-
-        -- Prevent the click events from propagating to the wrapper element
-        -- These click events are used to close the menu, and click events on
-        -- the wrapper are used to toggle it
-        let itemHTML = Types.uncheckedCastTo Types.HTMLElement $ _element_raw itemEl
-        void $ liftJSM $ EventM.on itemHTML GlobalEventHandlers.click $ EventM.stopPropagation
-
-        pure (itemEl, domEvent Click itemEl)
-
-    alterScroll menuEl hover elemMap
-
-    pure (clickIndex, searchInput, ic)
-
-  let nextIndex Nothing _ = 0
-      nextIndex (Just i) is = succ i `min` pred (length is)
-      prevIndex Nothing = 0
-      prevIndex (Just i) = 0 `max` pred i
-
-  -- Hover state is given when the arrow keys are used to move through items
-  hover <- holdDyn Nothing $ leftmost
-    [ fmap Just $ flip tag (keydown ArrowDown dropdownElement) $ nextIndex
-            <$> current hover <*> taggedActive pure current items
-    , fmap Just $ flip tag (keydown ArrowUp dropdownElement) $ prevIndex <$> current hover
-    , Nothing <$ taggedActive (const never) updated items
-    ]
-
-  -- The user chooses an option by clicking it or "hovering" with the
-  -- keyboard and pressing enter
-  let chooseIdx :: Event t Int = fmapMaybe id $ leftmost
-        [ clickIndex
-        , tag (current hover) $ keydown Enter dropdownElement
-        ]
-
-      choose :: Event t (k, Text)
-      choose = fmapMaybe id $ attachWith (&)
-        (taggedActive constant current itemMap)
-        (M.lookup . Just <$> chooseIdx)
-
-  selection <- holdDyn Nothing $ Just <$> choose
-
-  -- Add event listeners
-  let htmlElement = Types.uncheckedCastTo Types.HTMLElement $ _element_raw dropdownElement
-  void $ liftJSM $ EventM.on htmlElement GlobalEventHandlers.keyDown $ do
-    EventM.uiKeyCode >>= \k -> case keyCodeLookup (fromIntegral k) of
-      ArrowDown -> EventM.preventDefault
-      ArrowUp -> EventM.preventDefault
-      Escape -> HTMLElement.blur htmlElement
-      Enter -> HTMLElement.blur $ _textInput_element searchInput
-      _ -> pure ()
-
-  let textInputEl = Types.uncheckedCastTo Types.HTMLElement $ _textInput_element searchInput
-
-  void $ performEvent $ ffor (current isOpen <@ domEvent Mousedown ic) $
-    \fcs -> liftJSM $ bool HTMLElement.focus HTMLElement.blur fcs textInputEl
-
-  -- This delay allows the item click events to pass before closing the dropdown box
-  searchInputFocus <- delay 0.1 $ updated $ _textInput_hasFocus searchInput
-  initFocus <- sample $ current $ _textInput_hasFocus searchInput
-  let closeEvents = if _dropdownConfig_closeOnClickSelection then void clickIndex else never
-      openEvents = foldMap ($ searchInput) [domEvent Click, keydown Space, keydown Enter]
-
-  isOpen <- holdUniqDyn <=< holdDyn initFocus $ leftmost
-    [ False <$ closeEvents
-    , True <$ openEvents
-    , searchInputFocus
-    ]
-
+textDropdown
+  :: forall active t m.
+    ( SingActive active, UI t m
+    , Types.MonadJSM (Performable m), Types.MonadJSM m, DomBuilderSpace m ~ GhcjsDomSpace )
+  => DropdownConfig t Text -> Text -> Event t Text -> TaggedActive active t [Text]
+  -> m (Dropdown t Text)
+textDropdown conf ini evt items = do
+  let conf' = conf
+        { _dropdownConfig_search = Just (searchByToText id)
+          { _searchDropdownConfig_allowAdditions = True
+          }
+        }
+  d <- dropdown conf' (Identity ini) (fmapCheap Identity evt) $ ffor items $
+    M.fromList . fmap (\t -> (t, text t))
+  let v = ffor (allowAdditionsValue d) $ \case
+        Left t -> t
+        Right (Identity t) -> t
   pure $ Dropdown
-    { _dropdown_value = zipDyn search selection
-    , _dropdown_blur = closeEvents
-    , _dropdown_element = dropdownElement
+    { _dropdown_search = v
+    , _dropdown_value = v
+    , _dropdown_change = runIdentity <$> _dropdown_change d
+    , _dropdown_open = _dropdown_open d
+    , _dropdown_element = _dropdown_element d
     }
+

--- a/semantic-reflex/src/Reflex/Dom/SemanticUI/Message.hs
+++ b/semantic-reflex/src/Reflex/Dom/SemanticUI/Message.hs
@@ -22,7 +22,6 @@ module Reflex.Dom.SemanticUI.Message
 
 import Control.Lens.TH (makeLensesWith, lensRules, simpleLenses)
 
-import Control.Lens ((%~), (?~))
 import Data.Default
 import Data.Semigroup ((<>))
 import Reflex
@@ -30,7 +29,7 @@ import Reflex.Dom.Core
 
 import Reflex.Active
 import Reflex.Dom.SemanticUI.Common
-import Reflex.Dom.SemanticUI.Icon (Icon(Icon), icon, icon')
+import Reflex.Dom.SemanticUI.Icon (Icon(Icon), icon)
 import Reflex.Dom.SemanticUI.Transition
 
 data MessageType


### PR DESCRIPTION
This is a rewrite of the dropdown module. Main API change is the
addition of the `Event` argument to `dropdown`. Improvements:
- You can now update the value
- Searchable dropdowns are now first class rather than being in a separate (worse) function
- Searchable dropdowns are keyed by default. The old text-only search (with allow additions) dropdown behaviour is available in `textDropdown`.
- Dropdowns can be initialised with a custom wrapper (e.g. button, label, etc), this replaces the questionable config values that were used previously
- Dropdowns can open upwards
- No longer capture the space keypress event (matches Semantic-UI behaviour)