### PR TITLE
Bump reflex

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,12 +6,13 @@
     reflex-dom-contrib = hackGet ./deps/reflex-dom-contrib;
   };
 
-  overrides = self: super: {
-
+  overrides = self: super: with pkgs.haskell.lib; {
     # Haddock is broken in GHC 8.4's version:
     # https://github.com/haskell/haddock/issues/775
-    semantic-reflex = pkgs.haskell.lib.dontHaddock super.semantic-reflex;
+    semantic-reflex = dontHaddock super.semantic-reflex;
 
+    # https://github.com/reflex-frp/reflex-dom-contrib/pull/68
+    reflex-dom-contrib = doJailbreak super.reflex-dom-contrib;
   };
 
   shells =

--- a/deps/reflex-dom-contrib/github.json
+++ b/deps/reflex-dom-contrib/github.json
@@ -2,6 +2,6 @@
   "owner": "reflex-frp",
   "repo": "reflex-dom-contrib",
   "branch": "master",
-  "rev": "b9e2965dff062a4e13140f66d487362a34fe58b3",
-  "sha256": "1aa045mr82hdzzd8qlqhfrycgyhd29lad8rf7vsqykly9axpl52a"
+  "rev": "11db20865fd275362be9ea099ef88ded425789e7",
+  "sha256": "1rmcqg97hr87blp1vl15rnvsxp836c2dh89lwpyb7lvh86d7jwaf"
 }

--- a/semantic-reflex-example/semantic-reflex-example.cabal
+++ b/semantic-reflex-example/semantic-reflex-example.cabal
@@ -51,7 +51,7 @@ library
     , lens            >= 4.15.2
     , mtl
     , reflex-dom
-    , reflex-dom-core >= 0.5 && < 0.6
+    , reflex-dom-core >= 0.5 && < 0.7
     , reflex-dom-nested-routing
     , random
     , semantic-reflex

--- a/semantic-reflex/semantic-reflex.cabal
+++ b/semantic-reflex/semantic-reflex.cabal
@@ -67,8 +67,8 @@ library
     , lens              >= 4.15.2
     , mtl
     , random
-    , reflex            >= 0.5 && < 0.7
-    , reflex-dom-core   >= 0.5 && < 0.6
+    , reflex            >= 0.5 && < 0.8
+    , reflex-dom-core   >= 0.5 && < 0.7
     , ref-tf
     , semialign         >= 1
     , template-haskell

--- a/semantic-reflex/semantic-reflex.cabal
+++ b/semantic-reflex/semantic-reflex.cabal
@@ -67,7 +67,7 @@ library
     , lens              >= 4.15.2
     , mtl
     , random
-    , reflex            >= 0.5 && < 0.8
+    , reflex            >= 0.5 && < 0.9
     , reflex-dom-core   >= 0.5 && < 0.7
     , ref-tf
     , semialign         >= 1


### PR DESCRIPTION
This bumps reflex deps to current-ish versions of reflex-platform and reflex-dom contrib.  

`semantic-reflex` builds using current `obelisk` for me but the deps in this project complain about reflex bounds for some reason that will likely be obvious to someone a little more familiar with the infra than I am.