### PR TITLE
Fix export collision

### DIFF
--- a/semantic-reflex/src/Reflex/Dom/SemanticUI.hs
+++ b/semantic-reflex/src/Reflex/Dom/SemanticUI.hs
@@ -38,7 +38,7 @@ import Reflex.Dom.SemanticUI.Table      as Components
 import Reflex.Dom.SemanticUI.Transition as Components
 
 import Reflex as Reflex hiding (askEvents, list)
-import Reflex.Dom.Builder.Class as Reflex hiding (Drop, Error)
+import Reflex.Dom.Builder.Class as Reflex hiding (Drop, Error, SetValue)
 import Reflex.Dom.Builder.Immediate as Reflex
 import Reflex.Dom.Builder.InputDisabled as Reflex
 import Reflex.Dom.Builder.Static as Reflex
@@ -57,4 +57,3 @@ import Reflex.Dom.Widget.Input as Reflex (HasValue(..))
 
 import Data.Default (def)
 import Control.Lens ((&), (.~), (?~))
-


### PR DESCRIPTION
After some package set bumping I ran into

```src/Reflex/Dom/SemanticUI.hs:5:5: error:
    Conflicting exports for ‘SetValue’:
       ‘module Components’ exports ‘Components.SetValue’
         imported from ‘Reflex.Dom.SemanticUI.Transition’ at src/Reflex/Dom/SemanticUI.hs:38:1-53
         (and originally defined
            at src/Reflex/Dom/SemanticUI/Transition.hs:505:1-35)
       ‘module Reflex’ exports ‘Reflex.SetValue’
         imported from ‘Reflex.Dom.Builder.Class’ at src/Reflex/Dom/SemanticUI.hs:41:1-62
  |
5 |   , module Reflex
  |     ^^^^^^^^^^^^^
```

Probably triggered by https://github.com/reflex-frp/reflex-dom/commit/b9d7914b0166ce6c01ce98fb2a434e628e45c965. 
I'd expect this `hiding` to fail with a `reflex-dom` prior to the above change, but `nix-build -A ghc.semantic-reflex-example` of this PR works, so I guess CPP isn't needed?